### PR TITLE
Fix issue with CLIP being serialized in model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 *.py[cod]
 
 **/.DS_Store
+.env
 
 # Build output
 dist/

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ We show the similarity heatmap over the `f3rm/panda/scene_001` dataset for the "
 controls above (you can download this dataset using the `f3rm-download-data panda` command). Try playing around with
 different language queries and see what results you get!
 
-<img src="https://raw.githubusercontent.com/f3rm/f3rm/main/assets/images/ns_viewer/baymax_heatmap.png" width="500" alt="similarity in Output Render dropdown">
+<img src="https://raw.githubusercontent.com/f3rm/f3rm/main/assets/images/ns_viewer/baymax_heatmap.png" width="500" alt="similarity heatmap for Baymax">
 
 **Note:** if multiple positive queries are specified, we average their CLIP embeddings before computing the pair-wise
 softmax described in Section 3.3 of the [paper](https://arxiv.org/abs/2308.07931). The default temperature of 0.1 works

--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ the `f3rm` environment.
 
 ### Downloading Example Datasets
 
-We provide example datasets which you can download using the `f3rm-download-data` command. By default, the script will
-download all the datasets (requires ~300MB disk space) into the `datasets/f3rm` directory relative to your current
-directory.
+We provide example datasets of tabletop and room-scale environments which you can download using
+the `f3rm-download-data` command. By default, the script will download all the datasets (requires ~300MB disk space)
+into the `datasets/f3rm` directory relative to your current directory.
 
 Run `f3rm-download-data -h` to see how to download specific datasets or set your own save directory. We provide a short
 description and preview of each dataset in [assets/datasets.md](assets/datasets.md).
@@ -113,6 +113,9 @@ You can try F3RM with the example datasets which you can download following the
 [instructions here](#downloading-example-datasets) (try out `f3rm/panda/scene_001`). Alternatively, you can prepare your
 own datasets following the instructions in the
 [Nerfstudio documentation](https://docs.nerf.studio/en/latest/quickstart/custom_dataset.html).
+
+Note that while we focused on tabletop environments in the paper, F3RM can be scaled up to much larger environments. Try
+training feature fields on the example [rooms datasets](assets/datasets.md#rooms).
 
 You do not need to run the training to completion. We save a checkpoint every 2000 steps by default. To see all the
 options available for training, run `ns-train f3rm -h`.

--- a/f3rm/model.py
+++ b/f3rm/model.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass, field
+from functools import cached_property
 from typing import Dict, List, Optional, Type
 
 import torch
@@ -46,12 +47,49 @@ class FeatureFieldModelConfig(NerfactoModelConfig):
 
 
 @dataclass
-class _GuiState:
+class ViewerUtils:
+    pca_proj: Optional[torch.Tensor] = None
     positives: List[str] = field(default_factory=list)
     pos_embed: Optional[torch.Tensor] = None
     negatives: List[str] = field(default_factory=list)
     neg_embed: Optional[torch.Tensor] = None
     softmax_temp: float = 0.1
+    device: Optional[torch.device] = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    @cached_property
+    def clip(self):
+        from f3rm.features.clip import load
+        from f3rm.features.clip_extract import CLIPArgs
+
+        CONSOLE.print(f"Loading CLIP {CLIPArgs.model_name} for viewer")
+        model, _ = load(CLIPArgs.model_name, device=self.device)
+        model.eval()
+        return model
+
+    @torch.no_grad()
+    def handle_language_queries(self, raw_text: str, is_positive: bool):
+        """Compute CLIP embeddings based on queries and update state"""
+        from f3rm.features.clip import tokenize
+
+        texts = [x.strip() for x in raw_text.split(",") if x.strip()]
+        # Clear the GUI state if there are no texts
+        if not texts:
+            self.clear_positives() if is_positive else self.clear_negatives()
+            return
+        # Embed text queries
+        tokens = tokenize(texts).to(self.device)
+        embed = self.clip.encode_text(tokens).float()
+        if is_positive:
+            self.positives = texts
+            # Average embedding if we have multiple positives
+            embed = embed.mean(dim=0, keepdim=True)
+            embed /= embed.norm(dim=-1, keepdim=True)
+            self.pos_embed = embed
+        else:
+            self.negatives = texts
+            # We don't average the negatives as we compute pair-wise softmax
+            embed /= embed.norm(dim=-1, keepdim=True)
+            self.neg_embed = embed
 
     @property
     def has_positives(self) -> bool:
@@ -69,14 +107,22 @@ class _GuiState:
         self.negatives.clear()
         self.neg_embed = None
 
+    def update_softmax_temp(self, temp: float):
+        self.softmax_temp = temp
+
+    def reset_pca_proj(self):
+        self.pca_proj = None
+        CONSOLE.print("Reset PCA projection")
+
+
+viewer_utils = ViewerUtils()
+
 
 class FeatureFieldModel(NerfactoModel):
     config: FeatureFieldModelConfig
 
     feature_field: FeatureField
     renderer_feature: FeatureRenderer
-    pca_proj: Optional[torch.Tensor] = None
-    gui_state: _GuiState = _GuiState()
 
     def populate_modules(self):
         super().populate_modules()
@@ -103,72 +149,28 @@ class FeatureFieldModel(NerfactoModel):
         self.setup_gui()
 
     def setup_gui(self):
-        def refresh_pca_proj(_: ViewerButton):
-            self.pca_proj = None
-            CONSOLE.print("PCA projection cleared")
-
-        self.btn_refresh_pca = ViewerButton("Refresh PCA Projection", cb_hook=refresh_pca_proj)
-
-        # Setup GUI for language features if we're using CLIP
-        if self.kwargs["metadata"]["feature_type"] == "CLIP":
-            self.setup_language_gui()
-
-    def setup_language_gui(self):
-        from f3rm.features.clip import load, tokenize
-        from f3rm.features.clip_extract import CLIPArgs
-
-        device = self.kwargs["device"]
-        gui_state = self.gui_state
-        self._clip_model = None
-
-        # Load CLIP lazily to avoid loading it when not needed
-        def load_clip_model():
-            if self._clip_model is None:
-                CONSOLE.print(f"Loading CLIP {CLIPArgs.model_name} for Nerfstudio viewer")
-                self._clip_model, _ = load(CLIPArgs.model_name, device=device)
-
-        @torch.no_grad()
-        def update_gui_state(element: ViewerText, is_positive: bool):
-            """Compute CLIP embeddings based on text and update GUI state"""
-            load_clip_model()
-            texts = [x.strip() for x in element.value.split(",") if x.strip()]
-            # Clear the GUI state if there are no texts
-            if not texts:
-                gui_state.clear_positives() if is_positive else gui_state.clear_negatives()
-                return
-            # Embed text queries
-            tokens = tokenize(texts).to(device)
-            embed = self._clip_model.encode_text(tokens).float()
-            if is_positive:
-                gui_state.positives = texts
-                # Average embedding if we have multiple positives
-                embed = embed.mean(dim=0, keepdim=True)
-                embed /= embed.norm(dim=-1, keepdim=True)
-                gui_state.pos_embed = embed
-            else:
-                gui_state.negatives = texts
-                # We don't average the negatives as we compute pair-wise softmax
-                embed /= embed.norm(dim=-1, keepdim=True)
-                gui_state.neg_embed = embed
-
-        def update_softmax(element: ViewerNumber):
-            gui_state.softmax_temp = element.value
-            CONSOLE.print("Updated softmax temperature to", gui_state.softmax_temp)
-
+        viewer_utils.device = self.kwargs["device"]
         # Note: the GUI elements are shown based on alphabetical variable names
+        self.btn_refresh_pca = ViewerButton("Refresh PCA Projection", cb_hook=lambda _: viewer_utils.reset_pca_proj())
+
+        # Only setup GUI for language features if we're using CLIP
+        if self.kwargs["metadata"]["feature_type"] != "CLIP":
+            return
         self.hint_text = ViewerText(name="Note:", disabled=True, default_value="Use , to separate labels")
         self.lang_1_pos_text = ViewerText(
             name="Language (Positives)",
             default_value="",
-            cb_hook=lambda elem: update_gui_state(elem, is_positive=True),
+            cb_hook=lambda elem: viewer_utils.handle_language_queries(elem.value, is_positive=True),
         )
         self.lang_2_neg_text = ViewerText(
             name="Language (Negatives)",
             default_value="",
-            cb_hook=lambda elem: update_gui_state(elem, is_positive=False),
+            cb_hook=lambda elem: viewer_utils.handle_language_queries(elem.value, is_positive=False),
         )
         self.softmax_temp = ViewerNumber(
-            name="Softmax temperature", default_value=gui_state.softmax_temp, cb_hook=update_softmax
+            name="Softmax temperature",
+            default_value=viewer_utils.softmax_temp,
+            cb_hook=lambda elem: viewer_utils.update_softmax_temp(elem.value),
         )
 
     def get_param_groups(self) -> Dict[str, List[Parameter]]:
@@ -251,10 +253,12 @@ class FeatureFieldModel(NerfactoModel):
         outputs = super().get_outputs_for_camera_ray_bundle(camera_ray_bundle)
 
         # Compute PCA of features separately, so we can reuse the same projection matrix
-        outputs["feature_pca"], self.pca_proj, *_ = apply_pca_colormap_return_proj(outputs["feature"], self.pca_proj)
+        outputs["feature_pca"], viewer_utils.pca_proj, *_ = apply_pca_colormap_return_proj(
+            outputs["feature"], viewer_utils.pca_proj
+        )
 
         # Nothing else to do if not CLIP features or no positives
-        if self.kwargs["metadata"]["feature_type"] != "CLIP" or not self.gui_state.has_positives:
+        if self.kwargs["metadata"]["feature_type"] != "CLIP" or not viewer_utils.has_positives:
             return outputs
 
         # Normalize CLIP features rendered by feature field
@@ -262,8 +266,8 @@ class FeatureFieldModel(NerfactoModel):
         clip_features /= clip_features.norm(dim=-1, keepdim=True)
 
         # If there are no negatives, just show the cosine similarity with the positives
-        if not self.gui_state.has_negatives:
-            sims = clip_features @ self.gui_state.pos_embed.T
+        if not viewer_utils.has_negatives:
+            sims = clip_features @ viewer_utils.pos_embed.T
             # Show the mean similarity if there are multiple positives
             if sims.shape[-1] > 1:
                 sims = sims.mean(dim=-1, keepdim=True)
@@ -271,7 +275,7 @@ class FeatureFieldModel(NerfactoModel):
             return outputs
 
         # Use paired softmax method as described in the paper with positive and negative texts
-        text_embs = torch.cat([self.gui_state.pos_embed, self.gui_state.neg_embed], dim=0)
+        text_embs = torch.cat([viewer_utils.pos_embed, viewer_utils.neg_embed], dim=0)
         raw_sims = clip_features @ text_embs.T
 
         # Broadcast positive label similarities to all negative labels
@@ -280,7 +284,7 @@ class FeatureFieldModel(NerfactoModel):
         paired_sims = torch.cat([pos_sims, neg_sims], dim=-1)
 
         # Compute paired softmax
-        probs = (paired_sims / self.gui_state.softmax_temp).softmax(dim=-1)[..., :1]
+        probs = (paired_sims / viewer_utils.softmax_temp).softmax(dim=-1)[..., :1]
         torch.nan_to_num_(probs, nan=0.0)
         sims, _ = probs.min(dim=-1, keepdim=True)
         outputs["similarity"] = sims

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "f3rm"
-version = "0.0.3"
+version = "0.0.4"
 description = "F3RM: Feature Fields for Robotic Manipulation"
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
CLIP was being serialized into the `state_dict` of the model. This resulted into 1.1GB checkpoints in nerfstudio if the language queries were used in the viewer (which caused CLIP to be lazily loaded)

Moved this out to a `ViewerUtils` class. Checkpoints are now 177MB.

This does not break prior checkpoints from my tests.